### PR TITLE
Integrate layered framework into instructions and outline

### DIFF
--- a/Agent-instructions.md
+++ b/Agent-instructions.md
@@ -8,6 +8,25 @@ second iteration, add material.
 third iteration, create coherent chapters.
 maybe more..
 
+## Layered Approach
+
+The project runs on three meta layers:
+
+- **Layer 1 – Everyday Flow:** seven-step protocol for real conversations.
+- **Layer 2 – Symbolic Hints:** sidebars with nine cues pointing to higher ground:
+  1. *Feeling before form* – tone check and somatic scan.
+  2. *Identity as symbolic compiler* – ask for the source repo and change‑log.
+  3. *Quantum potential to symbolic attractors* – name the attractor and sample it.
+  4. *Entropy, grace, and symbolic gravity* – compress the narrative and invite a grace bid.
+  5. *Love as the first field* – offer a quick care gesture.
+  6. *Mythic memory* – surface archetypes and invite balance.
+  7. *Grammar as collapse function* – rotate **I / We / It** frames.
+  8. *Symbolic thermometer* – track state shifts; reset at 4/5.
+  9. *Fate as folded flow* – notice repeating patterns and try a counter‑fold.
+- **Layer 3 – Practitioner Protocol:** a 90‑minute session template with diagnostics, instruments (thermometer, grace log, archetype watch), rituals, and micro‑practices for facilitators.
+
+Use Layer 1 alone for general audiences; Layer 2 appears as callouts; Layer 3 serves as an appendix-level operations manual.
+
 ## 2) Project Overview
 	•	Project Work Title: From Misunderstanding to Higher Common Ground
 	•	Objective / Thesis: Misunderstandings are the default in human interaction. By making meanings, motives, power, and values explicit, readers can build a shared layer of integrity that survives disagreement and guides action.
@@ -15,6 +34,7 @@ maybe more..
 	•	Audience: Educated general readers; team leads; community organizers; parents; students.
 	•	Tone & Voice: Clear, concrete, non-judgmental, practical; narrative vignettes + plain-language explanations; no jargon without a one-line definition.
 	•	Output Formats: Markdown chapters (.md), vignette sets, checklists, “Simple Flow” card, small diagrams/figures (ASCII or linked images), back-of-book index, glossary.
+        •       Layered Framework: Layer 1 everyday flow; Layer 2 symbolic hints as sidebars; Layer 3 practitioner protocol as appendix.
 	•	Repository / Vault Path: From_Misunderstanding/ (see Structure below).
 	•	Citation Style: Light-touch inline links or footnotes when quoting facts/definitions; otherwise self-contained examples.
 	•	Length Guidance:
@@ -40,6 +60,8 @@ maybe more..
 	•	Expanded vignettes for every bullet in the outline.
 	•	Practical “Direct-Use Moves” (Chapter 6) as mini playbooks.
 	•	“Simple Flow You Can Use Tomorrow” card (text + print-ready layout).
+        •       Layer 2 sidebars highlighting symbolic hints.
+        •       Layer 3 appendix detailing the practitioner protocol (session template, instruments, rituals).
 	•	Reflection questions (2–3 per chapter).
 	•	Glossary entries for recurring terms (ambiguity, dependency, legitimacy, adaptation load, charter).
 	•	Back-of-book index (alpha → wired).

--- a/Outline.md
+++ b/Outline.md
@@ -7,6 +7,13 @@ The priciples work for professional, private and even public discurse.
 
 Misunderstandings aren’t bugs in human interaction—they’re the default. We each carry different assumptions, incentives, and power positions into the same room. Once we see why confusion arises naturally, we can work with it to build a shared layer of integrity that most people can stand on—even when we disagree.
 
+This guide works through three meta layers:
+1. **Layer 1 — Everyday Flow:** seven-step protocol for real conversations.
+2. **Layer 2 — Symbolic Hints:** sidebars cueing higher ground (tone checks, lineage, attractors, entropy compression, grace bids, archetype swaps, grammar rotation, temperature pings, counter‑folds).
+3. **Layer 3 — Practitioner Protocol:** a 90‑minute session template with diagnostics, instruments, and rituals for facilitators.
+
+Readers can use Layer 1 alone, add Layer 2 for reflection, and consult Layer 3 as an appendix-level manual.
+
 ⸻
 
 1) Why Misunderstanding Happens (Naturally)
@@ -130,7 +137,7 @@ Schedule a short, recurring “ground truth” session where lower-power partici
 
 ⸻
 
-7) A Simple Flow You Can Use Tomorrow
+7) A Simple Flow You Can Use Tomorrow (Layer 1)
 	1.	Clarify terms (close the ambiguity gap).
 	2.	Disclose dependencies (explain your pressures).
 	3.	Balance adaptation (share the burden of adjusting).
@@ -144,8 +151,19 @@ Schedule a short, recurring “ground truth” session where lower-power partici
 Where the Three Layers Show Up
 
 Layer 1 is the simple flow above.
-Layer 2 shows up as sidebars in each chapter with quick checks and prompts.
-Layer 3 lives in the appendix as a longer protocol for structured talks.
+
+Layer 2 appears as sidebars highlighting symbolic hints:
+- Feeling before form – tone check and somatic scan.
+- Identity as symbolic compiler – trace the belief's lineage and change‑log.
+- Quantum potential to symbolic attractors – name the pull and sample it.
+- Entropy, grace, and symbolic gravity – compress the story and invite a grace bid.
+- Love as the first field – lead with a care gesture.
+- Mythic memory – surface archetypes and invite a balancing role.
+- Grammar as collapse function – rotate **I / We / It** frames.
+- Symbolic thermometer – track state shifts; reset at 4/5.
+- Fate as folded flow – notice repeating patterns and try a counter‑fold.
+
+Layer 3 lives in the appendix as a practitioner protocol: a 90‑minute coherence session with diagnostics, instruments (symbolic thermometer, grace log, archetype watch), rituals (tone set, grammar rotation, dependency disclosure, grace bids, mythic mirror), micro-practices, and domain-specific applications.
 
 ⸻
 


### PR DESCRIPTION
## Summary
- Embed a three-layer model into the agent instructions, detailing everyday flow, symbolic hints, and a practitioner protocol.
- Note the layered framework within the project overview and standard deliverables for clearer guidance.
- Expand the outline with a meta-layer summary and a detailed breakdown of where each layer appears.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b009201d3c8325980c85365a323338