### PR TITLE
Add introductory chapter on personal core and roots of truth

### DIFF
--- a/From_Misunderstanding/00_meta/MOC_From_Misunderstanding.md
+++ b/From_Misunderstanding/00_meta/MOC_From_Misunderstanding.md
@@ -1,5 +1,6 @@
 # Map of Content - From Misunderstanding to Higher Common Ground
 
+- [Chapter 0 — Personal Core and the Roots of Truth](../40_chapters/00.md)
 - [Chapter 1 — Why Misunderstanding Happens (Naturally)](../40_chapters/01.md)
 - [Chapter 2 — The Social Physics Behind "Truth"](../40_chapters/02.md)
 - [Chapter 3 — Power Tilts the Conversation](../40_chapters/03.md)

--- a/From_Misunderstanding/40_chapters/00.md
+++ b/From_Misunderstanding/40_chapters/00.md
@@ -1,0 +1,21 @@
+# Chapter 0 — Personal Core and the Roots of Truth
+
+## Our personal core shapes what feels true
+- Our **personal core**—the values and stories that anchor identity—guides what we treat as real.
+- A teenager raised on open debate trusts dialogue over hierarchy.
+- Someone taught to "keep the peace" equates silence with safety.
+
+## Truth emerges where core meets shared reality
+- Street facts can differ from textbook facts until a shared test settles them.
+- A scientist trusts peer review; a pastor trusts scripture and lived witness.
+
+## Society layers rules to secure survival
+- When food and shelter are scarce, groups enforce sharing and safety (see **Maslow's pyramid**, a model of needs from basics to purpose).
+- Once secure, norms branch into belonging, esteem, and self-actualization.
+
+## People belong to a tribe in two ways
+- **Tribe**: a group with shared norms and identity.
+- **Born into the bond**: a child inherits a family, clan, or nation with preset roles and protections.
+- **Join a tribe**: an adult chooses a new community—online guild, profession, congregation—seeking a better fit with their core.
+
+**Key insight:** Knowing your core, testing truth together, and choosing aligned tribes opens the path to higher ground.


### PR DESCRIPTION
## Summary
- add new introductory chapter exploring personal core, truth testing, and tribal belonging
- update map of content to include the new chapter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b026d501188325b2a438032cdddf1f