### PR TITLE
Expand Chapter 1 on misunderstanding

### DIFF
--- a/From_Misunderstanding/40_chapters/01.md
+++ b/From_Misunderstanding/40_chapters/01.md
@@ -1,13 +1,26 @@
 # Chapter 1 — Why Misunderstanding Happens (Naturally)
 
-## Different defaults, same words
-- “I’ll be there soon” can mean 10 minutes to one person and an hour to another.
-- “We’re on the same page” often hides an unspoken framework; if it’s not actually shared, friction follows.
-- Traffic rules work because people broadly accept them, not just because they’re written.
+Misunderstanding isn’t a rare glitch. Every conversation carries hidden defaults: each person imports their own sense of timing, trust, and meaning. We think we agree because the words match, but the pictures in our heads rarely do. Seeing that gap is the first step toward any shared ground.
 
-## We smooth things over to keep flow
-- A friend misremembers your story; you let it go because it’s not the point.
-- In cross-cultural talk, you overlook small errors to stay connected.
-- At work, you don’t nitpick a minor misinterpretation to preserve goodwill.
+## Different defaults, same words ^c1-ambiguity
 
-**Key insight:** Misunderstanding is baked in by ambiguity and social smoothing. It’s not moral failure; it’s how humans maintain momentum.
+**[[Glossary: Ambiguity]]** is when a phrase can point to more than one meaning until someone clarifies it. We live in ambiguity because it keeps speech light and flexible. A friend texts, “I’ll be there soon,” picturing a quick ten minute walk; you wait nearly an hour and feel stood up. Both were honest. In a project meeting, the manager says, “We’re on the same page,” assuming everyone sees the plan from her perspective. A new hire nods along while secretly mapping an entirely different process. Even traffic rules show the role of shared defaults: stop signs work less because red paint commands us and more because most drivers agree to treat that hexagon as a real barrier.
+
+> Luis told his sister he would "swing by soon" to pick up their mom. He wrapped up errands, took a call, and arrived forty minutes later. Ana had been pacing by the door, car keys in hand. Neither was lying. Their families taught different clocks: in hers, "soon" meant finish what you're doing; in his, it meant after everything else is done.
+
+## We smooth things over to keep flow ^c1-social-smoothing
+
+**[[Glossary: Social smoothing]]** is the quiet choice to let small errors pass so the relationship stays easy. It keeps dinners pleasant and teams moving, but it also leaves mismatched ideas to pile up. A friend retells your story from last weekend but edits out the awkward part that mattered to you. You shrug it off; correcting them would feel petty. In a cross-cultural community meeting, a neighbor mixes up names and customs. Others nod politely to avoid embarrassment, and the mistake hardens into the "official" version. At work, a supervisor misreads a spreadsheet cell. The analyst decides not to nitpick in front of the group, only to spend the next week untangling the resulting confusion.
+
+> Mei, new to the city, attended her first neighborhood council. When she called the chair "Mr. Daniel," everyone smiled; his name was Danielle, and she preferred "Dani." No one corrected Mei on the spot. After the meeting, Dani thanked her privately and reflected on how often she had let similar slips slide to keep meetings moving. The pattern explained why newcomers rarely learned the group's informal norms.
+
+> Jamal led a software stand-up where the VP said the latest build was "basically done." The junior developers exchanged glances; half the features were still in draft. None spoke up, hoping to avoid a public clash. Two days later the release stalled, and the team spent a frantic night rewriting code the VP assumed already existed.
+
+## Key insight
+
+Misunderstanding is baked in by ambiguity and social smoothing. It’s not moral failure; it’s how humans maintain momentum. Naming these defaults makes them easier to navigate.
+
+### Reflection
+
+1. Recall a recent conversation where you assumed shared meaning. What hints did you miss that another reading was possible?
+2. Where do you tend to smooth over errors? What small clarification could you try next time?

--- a/From_Misunderstanding/60_index/index-wired.md
+++ b/From_Misunderstanding/60_index/index-wired.md
@@ -1,3 +1,4 @@
 # Index (Wired)
 
-*Placeholder for index entries with cross-links.*
+- [Ambiguity](../40_chapters/01.md#c1-ambiguity)
+- [Social smoothing](../40_chapters/01.md#c1-social-smoothing)


### PR DESCRIPTION
## Summary
- expand Chapter 1 with introductory context and detailed sections on ambiguity and social smoothing
- add vignettes, reflection questions, and glossary cross-links
- index updates to link new chapter anchors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b02c0860b88325be905d4130344079