### PR TITLE
Refine chapter flow and compile draft

### DIFF
--- a/From_Misunderstanding/00_meta/MOC_From_Misunderstanding.md
+++ b/From_Misunderstanding/00_meta/MOC_From_Misunderstanding.md
@@ -8,3 +8,4 @@
 - [Chapter 5 — Our Reach for a Universal Layer](../40_chapters/05.md)
 - [Chapter 6 — How to Climb Toward Higher Common Ground](../40_chapters/06.md)
 - [Chapter 7 — A Simple Flow You Can Use Tomorrow](../40_chapters/07.md)
+- [Comprehensive Draft](../30_drafts/book_draft.md)

--- a/From_Misunderstanding/30_drafts/book_draft.md
+++ b/From_Misunderstanding/30_drafts/book_draft.md
@@ -1,0 +1,259 @@
+# From Misunderstanding to Higher Common Ground
+
+# Chapter 0 — Personal Core and the Roots of Truth
+
+Our **personal core**—the bundle of values and stories that anchor identity—guides what we treat as real. A teenager raised on open debate trusts dialogue over hierarchy. Someone taught to "keep the peace" equates silence with safety. [[Glossary: Personal Core]]
+
+*Vignette (family):* At Sunday dinner, Mia's family recalls an incident from her childhood. Her uncle misremembers the outcome, but Mia stays quiet. Years of smoothing conflict taught her that harmony matters more than accuracy. Only later does she wonder whether speaking up would have changed the family narrative.
+
+Truth emerges when core meets shared reality. Street facts can differ from textbook facts until a shared test settles them. A scientist trusts peer review; a pastor trusts scripture and lived witness. Each approach can converge when they test claims together.
+
+*Vignette (work):* During a product review, Ethan cites data from a rapid user test. Sara, steeped in academic rigor, wants a larger sample. They agree to run a quick follow-up experiment. Their definitions of "proof" differ, but a joint test builds common ground.
+
+Societies layer rules to secure survival. When food and shelter are scarce, groups enforce sharing and safety. **Maslow's pyramid** is a model of human needs from basics to purpose. Once security arrives, norms branch into belonging, esteem, and self-actualization.
+
+*Vignette (civic):* After a storm knocks out power, neighbors in a high-rise organize a stairwell committee. Initial focus is food and medicine. Within days, conversations shift to who gets to use generators and how to allocate elevator time. The group builds rules in layers as needs change.
+
+People belong to a **tribe**—a group with shared norms and identity—in two ways. Some are **born into the bond**: a child inherits a family, clan, or nation with preset roles and protections. Others **join a tribe** later, seeking a better fit: an online guild, a profession, a congregation. Choosing or inheriting a tribe colors what counts as trustworthy and who we call "us." [[Glossary: Tribe]]
+
+**Key insight:** Knowing your core, testing truth together, and choosing aligned tribes opens the path to higher ground.
+
+Seeing how identity and shared tests shape reality sets the stage for the misunderstandings that follow us into every conversa­tion.
+
+**Reflection questions**
+1. When have you stayed quiet to keep peace, and what did it cost?
+2. Which tribes claim your loyalty, and how do they shape your sense of truth?
+
+
+# Chapter 1 — Why Misunderstanding Happens (Naturally)
+
+Misunderstanding isn’t a rare glitch. Building on the roots of personal identity, every conversation carries hidden defaults: each person imports their own sense of timing, trust, and meaning. We think we agree because the words match, but the pictures in our heads rarely do. Seeing that gap is the first step toward any shared ground.
+
+## Different defaults, same words ^c1-ambiguity
+
+**[[Glossary: Ambiguity]]** is when a phrase can point to more than one meaning until someone clarifies it. We live in ambiguity because it keeps speech light and flexible. A friend texts, “I’ll be there soon,” picturing a quick ten minute walk; you wait nearly an hour and feel stood up. Both were honest. In a project meeting, the manager says, “We’re on the same page,” assuming everyone sees the plan from her perspective. A new hire nods along while secretly mapping an entirely different process. Even traffic rules show the role of shared defaults: stop signs work less because red paint commands us and more because most drivers agree to treat that hexagon as a real barrier.
+
+> Luis told his sister he would "swing by soon" to pick up their mom. He wrapped up errands, took a call, and arrived forty minutes later. Ana had been pacing by the door, car keys in hand. Neither was lying. Their families taught different clocks: in hers, "soon" meant finish what you're doing; in his, it meant after everything else is done.
+
+## We smooth things over to keep flow ^c1-social-smoothing
+
+**[[Glossary: Social smoothing]]** is the quiet choice to let small errors pass so the relationship stays easy. It keeps dinners pleasant and teams moving, but it also leaves mismatched ideas to pile up. A friend retells your story from last weekend but edits out the awkward part that mattered to you. You shrug it off; correcting them would feel petty. In a cross-cultural community meeting, a neighbor mixes up names and customs. Others nod politely to avoid embarrassment, and the mistake hardens into the "official" version. At work, a supervisor misreads a spreadsheet cell. The analyst decides not to nitpick in front of the group, only to spend the next week untangling the resulting confusion.
+
+> Mei, new to the city, attended her first neighborhood council. When she called the chair "Mr. Daniel," everyone smiled; his name was Danielle, and she preferred "Dani." No one corrected Mei on the spot. After the meeting, Dani thanked her privately and reflected on how often she had let similar slips slide to keep meetings moving. The pattern explained why newcomers rarely learned the group's informal norms.
+
+> Jamal led a software stand-up where the VP said the latest build was "basically done." The junior developers exchanged glances; half the features were still in draft. None spoke up, hoping to avoid a public clash. Two days later the release stalled, and the team spent a frantic night rewriting code the VP assumed already existed.
+
+## Key insight
+
+Misunderstanding is baked in by ambiguity and social smoothing. It’s not moral failure; it’s how humans maintain momentum. Naming these defaults makes them easier to navigate.
+
+Spotting these everyday mismatches prepares us to examine the dependencies and recognition that bend our sense of truth.
+
+### Reflection
+
+1. Recall a recent conversation where you assumed shared meaning. What hints did you miss that another reading was possible?
+2. Where do you tend to smooth over errors? What small clarification could you try next time?
+
+
+# Chapter 2 — The Social Physics Behind "Truth"
+
+Truth feels solid, yet it bends with the pressures around us. Building on the everyday mismatches we just traced, each stance we take is tugged by debts, loyalties, and how others rate our right to speak. Seeing the social physics beneath belief helps us test claims without denying the people who hold them.
+
+## Dependence shapes belief
+
+**Dependency** is the web of practical or emotional pressures that make some opinions safer than others. [[Glossary: Dependency]] When your rent, reputation, or belonging hinges on agreement, dissent can feel reckless. So we nod along, even as our inner compass shakes.
+
+*Vignette (work):* Leah, a junior designer, disliked the new branding pitch. But the team lead had championed it, and Leah’s promotion depended on his favor. In the meeting she praised the plan, scribbling private notes on every flaw. Later, when the campaign flopped, she wondered why she had silenced herself.
+
+*Vignette (family):* At Thanksgiving, Uncle Ray turned the conversation to climate policy. Maya had researched rising sea levels for class, yet her parents’ small business relied on a coal contract. She softened her language, afraid blunt facts might sound like betrayal of the family livelihood.
+
+*Vignette (civic):* A city councilmember privately questioned her party’s stance on zoning. Developers funded her next campaign, and neighborhood activists were watching. On record, she echoed the party line, telling herself she’d push for tweaks once re‑elected.
+
+## Freedom without legitimacy is ignored
+
+**Legitimacy** is the recognition that a voice counts. [[Glossary: Legitimacy]] You can speak freely, but if others don’t see you as credible, your words fall through the floor. Status, credentials, and social location grant some statements weight while others evaporate.
+
+*Vignette (civic):* During a public hearing, a man experiencing homelessness described dangerous shelter conditions. Officials thanked him and moved on. Minutes later, a nonprofit director repeated the same points and the room finally took notes.
+
+*Vignette (family):* Ten-year-old Lila watched her father scold her brother for fibbing. “But you told Grandma we liked her casserole,” she said. The adults chuckled, framing it as cute rather than calling out the double standard.
+
+*Vignette (work):* When technician Omar raised safety concerns, management brushed him off. Months later a consultant issued the same warning with a polished report, and the company launched an urgent fix. Omar’s freedom to speak had never been enough.
+
+**Key insight:** What we call “truth” often tracks dependencies and recognition, not just evidence.
+
+These hidden tugs set the stage for power itself to tilt conversations, shaping who must adapt and who can ignore the strain.
+
+**Reflection questions**
+1. Where do dependencies in your life nudge you toward silence or agreement?
+2. Who do you dismiss as unqualified, and what might change if you granted them legitimacy?
+
+
+# Chapter 3 — Power Tilts the Conversation
+
+Power shapes conversations long before words are spoken. Following the social tugs on truth, who bends and who sets the terms depends on where each person stands on the gradient of influence. Naming that slope lets us redistribute the effort of adapting.
+
+## Who adapts to whom?
+
+**Adaptation load** is the effort required to adjust to someone else’s language, mood, or rules. [[Glossary: Adaptation Load]] Those with less leverage carry more of it. They scan faces, rehearse phrases, and swallow reactions to keep things smooth.
+
+*Vignette (work):* A waitress endures a customer’s sarcasm with a practiced smile. Her tip—and shift—depends on staying gracious, while the customer feels free to vent without consequence.
+
+*Vignette (family):* Eight-year-old Jonah studies his mother’s expression before asking for playtime. If her shoulders sag, he backs away. The adults rarely adjust to his moods; he is the one calibrating.
+
+*Vignette (civic):* At a town hall, volunteer organizers rearrange agendas whenever the mayor is late. They whisper reminders to speak respectfully, knowing one misstep could cost future support.
+
+## Power can isolate
+
+**Power gradient** describes how far someone sits from everyday consequences. [[Glossary: Power Gradient]] The steeper the gradient, the more filtered their feedback becomes.
+
+*Vignette (work):* A CEO tours the factory floor after a glowing quarterly report. Workers have been meeting quotas by skipping breaks, but supervisors highlight only success. The top hears applause, not strain.
+
+*Vignette (civic):* A celebrity tweets about a budget-friendly recipe, unaware that the suggested ingredients cost more than many families spend in a week. Years of assistants and catered sets have dulled her price sense.
+
+*Vignette (family):* Grandma Rosa insists the household is “just fine” while her grandchildren quietly handle repairs and bills she no longer sees. Her authority shields her from the mess that others tidy up.
+
+**Key insight:** The higher you are in a gradient, the less you must adapt—and the less you hear.
+
+With power dynamics on the table, we can look more closely at how questions of integrity, motive, and speed spark conflict.
+
+**Reflection questions**
+1. Where do you carry adaptation load, and where do others carry it for you?
+2. How might you reduce the power gradient in a conversation you lead?
+
+
+# Chapter 4 — Integrity, Motive, and Speed of Change
+
+We often assume integrity and speed should align, yet different worlds honor different tempos. After naming how power tilts conversations, we see arguments flare when we judge by our own clock without seeing the motives and values steering the other side.
+
+## Integrity is context-rated
+
+**Integrity** is staying aligned with your declared principles. [[Glossary: Integrity]] But what counts as “staying true” depends on the field you play in. In fast tech, investors cheer a quick pivot; lingering is branded **inflexible**. On a family farm, the handshake agreement lives for years, and breaking it brands you untrustworthy. Campaign strategists expect to chase polls, yet a pastor who constantly shifts doctrine loses the very flock seeking steadiness.
+
+*Vignette (work):* A start‑up scrapped its entire app after a competitor launched first. The team celebrated the move as smart agility. In the neighboring repair shop, the owner watched and shook his head; in his trade, you finish the job you promised, even if trends change.
+
+*Vignette (family):* Marta’s grandfather still works the orchard. He tells her, “Our word is our harvest.” When a supplier delays payment, he refuses a lucrative new contract with them, choosing slow security over quick cash.
+
+*Vignette (civic):* On the campaign trail, a candidate shifts her stance on zoning after listening to residents. Some voters praise her openness; others accuse her of chasing headlines. Meanwhile the town priest sticks to an unpopular teaching, insisting that stability is the truest care.
+
+## We judge actions by perceived intent
+
+**Motive** is the reason we believe drives a choice. [[Glossary: Motive]] The same move can look noble or self‑serving depending on the story we assign to it.
+
+*Vignette (family):* A father lets his teenager borrow the car past curfew to attend a friend’s memorial. The family sees compassion. When he later grants the same privilege so he can watch a game undisturbed, they call it hypocrisy.
+
+*Vignette (civic):* A politician reverses her vote on a policing bill. Supporters cite new evidence; opponents say she’s pandering to donors. Truth may lie in both, but perception cements the label.
+
+*Vignette (work):* A CEO announces a round of layoffs alongside a bonus plan. She frames it as protecting the company, yet staff whisper that stock options influenced the timing.
+
+## “The greater good” is contested terrain
+
+**Greater good** names the collective benefit we claim to serve when trade‑offs bite. [[Glossary: Greater Good]] Because values vary, so do the maps of what counts as “good.”
+
+*Vignette (civic):* Officials restrict movement during a public health crisis. Some applaud the lifesaving measure; others call it government overreach. Both groups claim to defend freedom.
+
+*Vignette (work):* A region debates shutting a coal plant. Environmental advocates point to cleaner air; workers fear losing generational jobs. Each argues for community welfare from a different axis.
+
+*Vignette (family):* Siblings argue over placing their mother in assisted living. One sees professional care as dignity; another views staying home as loyalty. Each calls their choice “what’s best.”
+
+**Key insight:** Disagreement often hides mismatched clocks (speed), yardsticks (integrity), and lenses (motive, good).
+
+These tensions hint at why many still search for something steadier—a universal layer of values that can hold across divides.
+
+**Reflection questions**
+1. Which contexts shape your sense of integrity, and where might others use a different yardstick?
+2. When you claim the greater good, whose values are you privileging?
+
+
+# Chapter 5 — Our Reach for a Universal Layer
+
+Even as cultures clash, people keep reaching for principles that hold beyond tribe. After wrestling with integrity, motive, and competing clocks, we look for a universal layer—a common sky—where truth and justice feel bigger than any single story.
+
+## We still want a common sky
+
+Across belief systems, there’s a pull toward alignment with something larger. Scientists chase objectivity while admitting every result carries error bars. Monks, pastors, and lay practitioners across traditions land on similar virtues: compassion, honesty, responsibility. The yearning is shared even when the language differs.
+
+*Vignette (family):* In a mixed‑faith marriage, Priya and Owen disagree on doctrine but agree their kids should learn to apologize and repair. They craft a nightly ritual: each person names one thing they are grateful for and one thing they could do better. The practice becomes their household “sky.”
+
+*Vignette (work):* Two rival labs compete to sequence a virus. When an outbreak hits a neighboring city, the lead scientists swap data over a video call, both citing the duty to “get it right for everyone.” Their shared standard of evidence bridges professional rivalry.
+
+*Vignette (civic):* After a local shooting, churches, mosques, and secular groups hold a joint vigil. Speakers take turns reading from different traditions, yet the crowd nods in rhythm when each mentions dignity and care for neighbors.
+
+## Shared values bind in practice
+
+Common values show up most clearly when stakes spike or games begin. Disasters flatten hierarchy as people rescue strangers. Sports stadiums turn diverse fans into one chanting body. Founding documents appeal to universal rights, even when practice lags behind those promises.
+
+*Vignette (civic):* When floodwaters rose, shop owners and students filled sandbags side by side. No one asked for voter registrations before handing out dry socks.
+
+*Vignette (work):* At the company retreat, engineers and sales reps from feuding departments ended up on the same softball team. Hours later they were trading strategies for smoother product launches.
+
+*Vignette (family):* Cousins who rarely speak rally to fund a relative’s medical bills. Arguments about politics pause as they share a spreadsheet and divide tasks.
+
+**Key insight:** There is a layer many can share; we touch it most easily under pressure or play.
+
+Reaching for that shared sky naturally raises the question of how to climb toward it in daily conversations, which the next chapter tackles with concrete moves.
+
+**Reflection questions**
+1. When have you felt part of something larger than your usual group?
+2. What small practice could you adopt to remind yourself of shared values with others?
+
+
+# Chapter 6 — How to Climb Toward Higher Common Ground
+
+These eight moves translate the book’s insights into actions you can try tomorrow. Coming down from our search for a common sky, practised lightly but often, they build the muscle of shared integrity.
+
+1) **Make meanings explicit.** Clarify terms upfront to shrink ambiguity.
+
+"When I say soon, I mean within 15 minutes. What does soon mean to you?"
+
+2) **Name dependencies to de-bias truth.** Share the pressures shaping your stance.
+
+"Part of my stance is shaped by my role/team/family. Here’s where I’m not free—and where I am."
+
+3) **Rebalance the adaptation load.** Share the burden of adjusting.
+Leaders: ask for unfiltered feedback; juniors: request a turn to set terms.
+
+"For five minutes, could we use my definitions and then yours?"
+
+4) **Surface motives without accusation.** Check intentions before judging.
+
+"I want to check intent: are we changing course because we learned, or because optics changed?"
+
+5) **Separate speed from integrity.** Decide what is fixed and what can flex.
+
+"What must stay non-negotiable, and what can pivot fast? Let’s make two lists."
+
+6) **Map the ‘greater good’ explicitly.** Make values and trade-offs visible.
+Put values on a board (safety, freedom, jobs, environment, dignity). Mark trade-offs you accept and why.
+
+"Which value wins in a tie, and for how long?"
+
+7) **Build a small shared charter.** Commit to a few principles you’ll enact now.
+Three to five principles you’ll enact now (e.g., “steel-man the other side before critiquing,” “timestamp claims,” “own dependency disclosures,” “seek disconfirming feedback once per decision”).
+
+8) **Create a feedback loop that can reach the top.** Give lower-power voices a regular path to speak.
+Schedule a short, recurring “ground truth” session where lower-power participants set the agenda.
+
+With practice, these moves converge into a quick checklist—a simple flow you can keep on hand, outlined next.
+
+**Reflection questions**
+1. Which move feels easiest to try in your next conversation?
+2. How could you invite others to practice one of these moves with you?
+
+
+# Chapter 7 — A Simple Flow You Can Use Tomorrow
+
+When time is tight, this seven-step checklist keeps conversations grounded. Distilling the eight moves into a portable form, you can run through it in order or grab the step you need most.
+
+1. Clarify terms (close the ambiguity gap).
+2. Disclose dependencies (explain your pressures).
+3. Balance adaptation (share the burden of adjusting).
+4. Check motives (learning vs. optics).
+5. Pin integrity vs. speed (what’s fixed, what flexes).
+6. Chart the greater good (name values, trade-offs, time horizon).
+7. Agree on a mini-charter + loop (principles you’ll actually practice, and when you’ll revisit them).
+
+**Reflection questions**
+1. Which step do you tend to skip, and what happens when you do?
+2. Who could benefit from keeping this flow handy alongside you?
+
+

--- a/From_Misunderstanding/40_chapters/00.md
+++ b/From_Misunderstanding/40_chapters/00.md
@@ -16,6 +16,8 @@ People belong to a **tribe**—a group with shared norms and identity—in two w
 
 **Key insight:** Knowing your core, testing truth together, and choosing aligned tribes opens the path to higher ground.
 
+Seeing how identity and shared tests shape reality sets the stage for the misunderstandings that follow us into every conversa­tion.
+
 **Reflection questions**
 1. When have you stayed quiet to keep peace, and what did it cost?
 2. Which tribes claim your loyalty, and how do they shape your sense of truth?

--- a/From_Misunderstanding/40_chapters/01.md
+++ b/From_Misunderstanding/40_chapters/01.md
@@ -1,6 +1,6 @@
 # Chapter 1 — Why Misunderstanding Happens (Naturally)
 
-Misunderstanding isn’t a rare glitch. Every conversation carries hidden defaults: each person imports their own sense of timing, trust, and meaning. We think we agree because the words match, but the pictures in our heads rarely do. Seeing that gap is the first step toward any shared ground.
+Misunderstanding isn’t a rare glitch. Building on the roots of personal identity, every conversation carries hidden defaults: each person imports their own sense of timing, trust, and meaning. We think we agree because the words match, but the pictures in our heads rarely do. Seeing that gap is the first step toward any shared ground.
 
 ## Different defaults, same words ^c1-ambiguity
 
@@ -19,6 +19,8 @@ Misunderstanding isn’t a rare glitch. Every conversation carries hidden defaul
 ## Key insight
 
 Misunderstanding is baked in by ambiguity and social smoothing. It’s not moral failure; it’s how humans maintain momentum. Naming these defaults makes them easier to navigate.
+
+Spotting these everyday mismatches prepares us to examine the dependencies and recognition that bend our sense of truth.
 
 ### Reflection
 

--- a/From_Misunderstanding/40_chapters/02.md
+++ b/From_Misunderstanding/40_chapters/02.md
@@ -1,6 +1,6 @@
 # Chapter 2 — The Social Physics Behind "Truth"
 
-Truth feels solid, yet it bends with the pressures around us. Each stance we take is tugged by debts, loyalties, and how others rate our right to speak. Seeing the social physics beneath belief helps us test claims without denying the people who hold them.
+Truth feels solid, yet it bends with the pressures around us. Building on the everyday mismatches we just traced, each stance we take is tugged by debts, loyalties, and how others rate our right to speak. Seeing the social physics beneath belief helps us test claims without denying the people who hold them.
 
 ## Dependence shapes belief
 
@@ -23,6 +23,8 @@ Truth feels solid, yet it bends with the pressures around us. Each stance we tak
 *Vignette (work):* When technician Omar raised safety concerns, management brushed him off. Months later a consultant issued the same warning with a polished report, and the company launched an urgent fix. Omar’s freedom to speak had never been enough.
 
 **Key insight:** What we call “truth” often tracks dependencies and recognition, not just evidence.
+
+These hidden tugs set the stage for power itself to tilt conversations, shaping who must adapt and who can ignore the strain.
 
 **Reflection questions**
 1. Where do dependencies in your life nudge you toward silence or agreement?

--- a/From_Misunderstanding/40_chapters/03.md
+++ b/From_Misunderstanding/40_chapters/03.md
@@ -1,6 +1,6 @@
 # Chapter 3 — Power Tilts the Conversation
 
-Power shapes conversations long before words are spoken. Who bends and who sets the terms depends on where each person stands on the gradient of influence. Naming that slope lets us redistribute the effort of adapting.
+Power shapes conversations long before words are spoken. Following the social tugs on truth, who bends and who sets the terms depends on where each person stands on the gradient of influence. Naming that slope lets us redistribute the effort of adapting.
 
 ## Who adapts to whom?
 
@@ -23,6 +23,8 @@ Power shapes conversations long before words are spoken. Who bends and who sets 
 *Vignette (family):* Grandma Rosa insists the household is “just fine” while her grandchildren quietly handle repairs and bills she no longer sees. Her authority shields her from the mess that others tidy up.
 
 **Key insight:** The higher you are in a gradient, the less you must adapt—and the less you hear.
+
+With power dynamics on the table, we can look more closely at how questions of integrity, motive, and speed spark conflict.
 
 **Reflection questions**
 1. Where do you carry adaptation load, and where do others carry it for you?

--- a/From_Misunderstanding/40_chapters/04.md
+++ b/From_Misunderstanding/40_chapters/04.md
@@ -1,6 +1,6 @@
 # Chapter 4 — Integrity, Motive, and Speed of Change
 
-We often assume integrity and speed should align, yet different worlds honor different tempos. Arguments flare when we judge by our own clock without seeing the motives and values steering the other side.
+We often assume integrity and speed should align, yet different worlds honor different tempos. After naming how power tilts conversations, we see arguments flare when we judge by our own clock without seeing the motives and values steering the other side.
 
 ## Integrity is context-rated
 
@@ -33,6 +33,8 @@ We often assume integrity and speed should align, yet different worlds honor dif
 *Vignette (family):* Siblings argue over placing their mother in assisted living. One sees professional care as dignity; another views staying home as loyalty. Each calls their choice “what’s best.”
 
 **Key insight:** Disagreement often hides mismatched clocks (speed), yardsticks (integrity), and lenses (motive, good).
+
+These tensions hint at why many still search for something steadier—a universal layer of values that can hold across divides.
 
 **Reflection questions**
 1. Which contexts shape your sense of integrity, and where might others use a different yardstick?

--- a/From_Misunderstanding/40_chapters/05.md
+++ b/From_Misunderstanding/40_chapters/05.md
@@ -1,6 +1,6 @@
 # Chapter 5 — Our Reach for a Universal Layer
 
-Even as cultures clash, people keep reaching for principles that hold beyond tribe. We look for a universal layer—a common sky—where truth and justice feel bigger than any single story.
+Even as cultures clash, people keep reaching for principles that hold beyond tribe. After wrestling with integrity, motive, and competing clocks, we look for a universal layer—a common sky—where truth and justice feel bigger than any single story.
 
 ## We still want a common sky
 
@@ -23,6 +23,8 @@ Common values show up most clearly when stakes spike or games begin. Disasters f
 *Vignette (family):* Cousins who rarely speak rally to fund a relative’s medical bills. Arguments about politics pause as they share a spreadsheet and divide tasks.
 
 **Key insight:** There is a layer many can share; we touch it most easily under pressure or play.
+
+Reaching for that shared sky naturally raises the question of how to climb toward it in daily conversations, which the next chapter tackles with concrete moves.
 
 **Reflection questions**
 1. When have you felt part of something larger than your usual group?

--- a/From_Misunderstanding/40_chapters/06.md
+++ b/From_Misunderstanding/40_chapters/06.md
@@ -1,6 +1,6 @@
 # Chapter 6 — How to Climb Toward Higher Common Ground
 
-These eight moves translate the book’s insights into actions you can try tomorrow. Practiced lightly but often, they build the muscle of shared integrity.
+These eight moves translate the book’s insights into actions you can try tomorrow. Coming down from our search for a common sky, practised lightly but often, they build the muscle of shared integrity.
 
 1) **Make meanings explicit.** Clarify terms upfront to shrink ambiguity.
 
@@ -33,6 +33,8 @@ Three to five principles you’ll enact now (e.g., “steel-man the other side b
 
 8) **Create a feedback loop that can reach the top.** Give lower-power voices a regular path to speak.
 Schedule a short, recurring “ground truth” session where lower-power participants set the agenda.
+
+With practice, these moves converge into a quick checklist—a simple flow you can keep on hand, outlined next.
 
 **Reflection questions**
 1. Which move feels easiest to try in your next conversation?

--- a/From_Misunderstanding/40_chapters/07.md
+++ b/From_Misunderstanding/40_chapters/07.md
@@ -1,6 +1,6 @@
 # Chapter 7 — A Simple Flow You Can Use Tomorrow
 
-When time is tight, this seven-step checklist keeps conversations grounded. Run through it in order or grab the step you need most.
+When time is tight, this seven-step checklist keeps conversations grounded. Distilling the eight moves into a portable form, you can run through it in order or grab the step you need most.
 
 1. Clarify terms (close the ambiguity gap).
 2. Disclose dependencies (explain your pressures).


### PR DESCRIPTION
## Summary
- Integrate transitional lines across Chapters 0–7 to connect themes and prepare the reader for upcoming topics.
- Compile a comprehensive `book_draft.md` that stitches all chapters into a single manuscript and link it in the map of content.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b031f82a2083259a3bc47888272819