### PR TITLE
Rename assets folder and add TODO checklist

### DIFF
--- a/Agent-instructions.md
+++ b/Agent-instructions.md
@@ -181,7 +181,7 @@ Three pre-filled cards for this project
 
 	•	Goal: Produce a one-page, print-ready text for Chapter 7’s flow; add a 10-minute micro-meeting variant.
 	•	Requirements: Seven steps with micro-prompts; no jargon.
-	•	Deliverable: 40_assets/simple-flow-card.md (ready to export to PDF).
+	•	Deliverable: 45_assets/simple-flow-card.md (ready to export to PDF).
 
 ⸻
 
@@ -243,7 +243,7 @@ From_Misunderstanding/
   20_notes/              # scratch, comparisons, matrices
   30_drafts/             # chapter drafts
   40_chapters/           # stitched chapters ready for review
-  40_assets/             # flow card, diagrams
+  45_assets/             # flow card, diagrams
   50_glossary/           # glossary entries
   60_index/              # index alpha/wired
   99_archive/

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,7 @@
+# TODO
+
+- [ ] Populate `45_assets` with flow card and diagram files.
+- [ ] Add research notes to `20_notes`.
+- [ ] Create glossary entries in `50_glossary`.
+- [ ] Ensure chapters link to glossary terms and index anchors.
+- [ ] Add automated tests or linting for the project.


### PR DESCRIPTION
## Summary
- Rename duplicated `40_assets` directory to `45_assets` for unique numbering
- Update project instructions to reference the new `45_assets` path
- Add repository-wide `todo.md` capturing follow-up tasks

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7a42f66fc8325aacccaefdd90ff0d