### PR TITLE
feat: modularize stylegan manager

### DIFF
--- a/stylegan_manager/__init__.py
+++ b/stylegan_manager/__init__.py
@@ -1,0 +1,13 @@
+"""Top-level package for StyleGAN manager utilities."""
+
+from .models import StyleGANModel
+from .walks import LatentWalk
+from .videos import VideoGenerator
+from .ui import StyleGANCLI
+
+__all__ = [
+    "StyleGANModel",
+    "LatentWalk",
+    "VideoGenerator",
+    "StyleGANCLI",
+]

--- a/stylegan_manager/models/__init__.py
+++ b/stylegan_manager/models/__init__.py
@@ -1,0 +1,3 @@
+from .manager import StyleGANModel
+
+__all__ = ["StyleGANModel"]

--- a/stylegan_manager/models/manager.py
+++ b/stylegan_manager/models/manager.py
@@ -1,0 +1,13 @@
+class StyleGANModel:
+    """Simple placeholder representing a StyleGAN model."""
+
+    def __init__(self, weights_path: str):
+        self.weights_path = weights_path
+
+    def generate(self, latent):
+        """Generate an image from a latent vector.
+
+        For this placeholder implementation, return a string
+        describing the latent vector used.
+        """
+        return f"image_from_{latent}"

--- a/stylegan_manager/ui/__init__.py
+++ b/stylegan_manager/ui/__init__.py
@@ -1,0 +1,3 @@
+from .cli import StyleGANCLI
+
+__all__ = ["StyleGANCLI"]

--- a/stylegan_manager/ui/cli.py
+++ b/stylegan_manager/ui/cli.py
@@ -1,0 +1,18 @@
+from ..models import StyleGANModel
+from ..walks import LatentWalk
+from ..videos import VideoGenerator
+
+
+class StyleGANCLI:
+    """Simple command-style interface tying together model, walks and videos."""
+
+    def __init__(self, weights_path: str):
+        self.model = StyleGANModel(weights_path)
+        self.video_gen = VideoGenerator()
+
+    def create_walk_video(self, start_latent, end_latent, steps: int, out_file: str) -> str:
+        """Generate frames from a latent walk and compose them into a text 'video'."""
+        walker = LatentWalk(self.model)
+        latents = walker.interpolate(start_latent, end_latent, steps)
+        frames = [self.model.generate(latent) for latent in latents]
+        return self.video_gen.create(frames, out_file)

--- a/stylegan_manager/videos/__init__.py
+++ b/stylegan_manager/videos/__init__.py
@@ -1,0 +1,3 @@
+from .generator import VideoGenerator
+
+__all__ = ["VideoGenerator"]

--- a/stylegan_manager/videos/generator.py
+++ b/stylegan_manager/videos/generator.py
@@ -1,0 +1,8 @@
+class VideoGenerator:
+    """Placeholder video generator that writes frames to a text file."""
+
+    def create(self, frames, out_file: str) -> str:
+        with open(out_file, "w") as fh:
+            for frame in frames:
+                fh.write(str(frame) + "\n")
+        return out_file

--- a/stylegan_manager/walks/__init__.py
+++ b/stylegan_manager/walks/__init__.py
@@ -1,0 +1,3 @@
+from .latent_walk import LatentWalk
+
+__all__ = ["LatentWalk"]

--- a/stylegan_manager/walks/latent_walk.py
+++ b/stylegan_manager/walks/latent_walk.py
@@ -1,0 +1,16 @@
+from typing import Iterable, List
+
+
+class LatentWalk:
+    """Utility for interpolating between latent vectors."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def interpolate(self, start: List[float], end: List[float], steps: int) -> Iterable[List[float]]:
+        """Yield latent vectors interpolated from start to end."""
+        if steps < 2:
+            raise ValueError("steps must be at least 2")
+        for i in range(steps):
+            t = i / (steps - 1)
+            yield [(1 - t) * s + t * e for s, e in zip(start, end)]


### PR DESCRIPTION
## Summary
- scaffold a new `stylegan_manager` package with dedicated subpackages for models, walks, videos, and ui.
- expose core classes in each package's `__init__` and provide placeholder implementations of `StyleGANModel`, `LatentWalk`, `VideoGenerator`, and `StyleGANCLI`.

## Testing
- `python -m py_compile $(find stylegan_manager -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b9fc398c808325abe0007c8bcd2e8e